### PR TITLE
Fixed failing sorts after multiple calls to makesortable and extended matches for percent values

### DIFF
--- a/sorttable.js
+++ b/sorttable.js
@@ -1,6 +1,6 @@
 /*
   SortTable
-  version 2 - Virgile Högman patch 2.1.0
+  version 2 - Virgile Högman patch 2.2.0
   7th April 2007
   Stuart Langridge, http://www.kryogenix.org/code/browser/sorttable/
 
@@ -89,9 +89,12 @@ sorttable = {
 	      // make it clickable to sort
 	      headrow[i].sorttable_columnindex = i;
 	      headrow[i].sorttable_tbody = table.tBodies[0];
-        // HerrVigg
-        // if makesortable is called several times on same table, different handlers were stacked!
+        // patch Virgile Högman - repeated handlers
+        // if makesortable is called several times on same table,
+        // different handlers could be stacked and cancel the sort!
         // innerSort function must be unique for this instance of sorttable
+        // and therefore stored in object (anonymous function can't be used)
+        // so that addListener will not register same handler again
         // see section "Multiple identical event listeners" here:
         //https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener
 	      dean_addEvent(headrow[i],"click", sorttable.innerSort);
@@ -160,8 +163,6 @@ sorttable = {
     //sorttable.shaker_sort(row_array, this.sorttable_sortfunction);
     /* and comment out this one */
     row_array.sort(this.sorttable_sortfunction);
-    /* HerrVigg reverse order on first click */
-    row_array.reverse();
 
     tb = this.sorttable_tbody;
     for (var j=0; j<row_array.length; j++) {
@@ -177,7 +178,7 @@ sorttable = {
     for (var i=0; i<table.tBodies[0].rows.length; i++) {
       text = sorttable.getInnerText(table.tBodies[0].rows[i].cells[column]);
       if (text != '') {
-        // patch Virgile Högman for spaces before %
+        // patch Virgile Högman for spaces and tabs before %
         if (text.match(/^-?[£$¤]?[\d,.]+[ \t]*%?$/)) {
           return sorttable.sort_numeric;
         }
@@ -217,7 +218,7 @@ sorttable = {
     hasInputs = (typeof node.getElementsByTagName == 'function') &&
                  node.getElementsByTagName('input').length;
 
-    if (node.getAttribute("sorttable_customkey") != null) {
+    if (node.nodeType == 1 && node.getAttribute("sorttable_customkey") != null) {
       return node.getAttribute("sorttable_customkey");
     }
     else if (typeof node.textContent != 'undefined' && !hasInputs) {
@@ -275,6 +276,7 @@ sorttable = {
     return aa-bb;
   },
   sort_alpha: function(a,b) {
+    return a[0].localeCompare(b[0]);    
     if (a[0]==b[0]) return 0;
     if (a[0]<b[0]) return -1;
     return 1;

--- a/sorttable.js
+++ b/sorttable.js
@@ -1,6 +1,6 @@
 /*
   SortTable
-  version 2
+  version 2 - Virgile Högman patch 2.1.0
   7th April 2007
   Stuart Langridge, http://www.kryogenix.org/code/browser/sorttable/
 
@@ -89,78 +89,86 @@ sorttable = {
 	      // make it clickable to sort
 	      headrow[i].sorttable_columnindex = i;
 	      headrow[i].sorttable_tbody = table.tBodies[0];
-	      dean_addEvent(headrow[i],"click", sorttable.innerSortFunction = function(e) {
-
-          if (this.className.search(/\bsorttable_sorted\b/) != -1) {
-            // if we're already sorted by this column, just
-            // reverse the table, which is quicker
-            sorttable.reverse(this.sorttable_tbody);
-            this.className = this.className.replace('sorttable_sorted',
-                                                    'sorttable_sorted_reverse');
-            this.removeChild(document.getElementById('sorttable_sortfwdind'));
-            sortrevind = document.createElement('span');
-            sortrevind.id = "sorttable_sortrevind";
-            sortrevind.innerHTML = stIsIE ? '&nbsp<font face="webdings">5</font>' : '&nbsp;&#x25B4;';
-            this.appendChild(sortrevind);
-            return;
-          }
-          if (this.className.search(/\bsorttable_sorted_reverse\b/) != -1) {
-            // if we're already sorted by this column in reverse, just
-            // re-reverse the table, which is quicker
-            sorttable.reverse(this.sorttable_tbody);
-            this.className = this.className.replace('sorttable_sorted_reverse',
-                                                    'sorttable_sorted');
-            this.removeChild(document.getElementById('sorttable_sortrevind'));
-            sortfwdind = document.createElement('span');
-            sortfwdind.id = "sorttable_sortfwdind";
-            sortfwdind.innerHTML = stIsIE ? '&nbsp<font face="webdings">6</font>' : '&nbsp;&#x25BE;';
-            this.appendChild(sortfwdind);
-            return;
-          }
-
-          // remove sorttable_sorted classes
-          theadrow = this.parentNode;
-          forEach(theadrow.childNodes, function(cell) {
-            if (cell.nodeType == 1) { // an element
-              cell.className = cell.className.replace('sorttable_sorted_reverse','');
-              cell.className = cell.className.replace('sorttable_sorted','');
-            }
-          });
-          sortfwdind = document.getElementById('sorttable_sortfwdind');
-          if (sortfwdind) { sortfwdind.parentNode.removeChild(sortfwdind); }
-          sortrevind = document.getElementById('sorttable_sortrevind');
-          if (sortrevind) { sortrevind.parentNode.removeChild(sortrevind); }
-
-          this.className += ' sorttable_sorted';
-          sortfwdind = document.createElement('span');
-          sortfwdind.id = "sorttable_sortfwdind";
-          sortfwdind.innerHTML = stIsIE ? '&nbsp<font face="webdings">6</font>' : '&nbsp;&#x25BE;';
-          this.appendChild(sortfwdind);
-
-	        // build an array to sort. This is a Schwartzian transform thing,
-	        // i.e., we "decorate" each row with the actual sort key,
-	        // sort based on the sort keys, and then put the rows back in order
-	        // which is a lot faster because you only do getInnerText once per row
-	        row_array = [];
-	        col = this.sorttable_columnindex;
-	        rows = this.sorttable_tbody.rows;
-	        for (var j=0; j<rows.length; j++) {
-	          row_array[row_array.length] = [sorttable.getInnerText(rows[j].cells[col]), rows[j]];
-	        }
-	        /* If you want a stable sort, uncomment the following line */
-	        //sorttable.shaker_sort(row_array, this.sorttable_sortfunction);
-	        /* and comment out this one */
-	        row_array.sort(this.sorttable_sortfunction);
-
-	        tb = this.sorttable_tbody;
-	        for (var j=0; j<row_array.length; j++) {
-	          tb.appendChild(row_array[j][1]);
-	        }
-
-	        delete row_array;
-	      });
+        // HerrVigg
+        // if makesortable is called several times on same table, different handlers were stacked!
+        // innerSort function must be unique for this instance of sorttable
+        // see section "Multiple identical event listeners" here:
+        //https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener
+	      dean_addEvent(headrow[i],"click", sorttable.innerSort);
 	    }
     }
+  },
+
+  innerSort: function(event) {
+    if (this.className.search(/\bsorttable_sorted\b/) != -1) {
+      // if we're already sorted by this column, just
+      // reverse the table, which is quicker
+      sorttable.reverse(this.sorttable_tbody);
+      this.className = this.className.replace('sorttable_sorted',
+                                              'sorttable_sorted_reverse');
+      this.removeChild(document.getElementById('sorttable_sortfwdind'));
+      sortrevind = document.createElement('span');
+      sortrevind.id = "sorttable_sortrevind";
+      sortrevind.innerHTML = stIsIE ? '&nbsp<font face="webdings">5</font>' : '&nbsp;&#x25B4;';
+      this.appendChild(sortrevind);
+      return;
+    }
+    if (this.className.search(/\bsorttable_sorted_reverse\b/) != -1) {
+      // if we're already sorted by this column in reverse, just
+      // re-reverse the table, which is quicker
+      sorttable.reverse(this.sorttable_tbody);
+      this.className = this.className.replace('sorttable_sorted_reverse',
+                                              'sorttable_sorted');
+      this.removeChild(document.getElementById('sorttable_sortrevind'));
+      sortfwdind = document.createElement('span');
+      sortfwdind.id = "sorttable_sortfwdind";
+      sortfwdind.innerHTML = stIsIE ? '&nbsp<font face="webdings">6</font>' : '&nbsp;&#x25BE;';
+      this.appendChild(sortfwdind);
+      return;
+    }
+
+    // remove sorttable_sorted classes
+    theadrow = this.parentNode;
+    forEach(theadrow.childNodes, function(cell) {
+      if (cell.nodeType == 1) { // an element
+        cell.className = cell.className.replace('sorttable_sorted_reverse','');
+        cell.className = cell.className.replace('sorttable_sorted','');
+      }
+    });
+    sortfwdind = document.getElementById('sorttable_sortfwdind');
+    if (sortfwdind) { sortfwdind.parentNode.removeChild(sortfwdind); }
+    sortrevind = document.getElementById('sorttable_sortrevind');
+    if (sortrevind) { sortrevind.parentNode.removeChild(sortrevind); }
+
+    this.className += ' sorttable_sorted';
+    sortfwdind = document.createElement('span');
+    sortfwdind.id = "sorttable_sortfwdind";
+    sortfwdind.innerHTML = stIsIE ? '&nbsp<font face="webdings">6</font>' : '&nbsp;&#x25BE;';
+    this.appendChild(sortfwdind);
+
+    // build an array to sort. This is a Schwartzian transform thing,
+    // i.e., we "decorate" each row with the actual sort key,
+    // sort based on the sort keys, and then put the rows back in order
+    // which is a lot faster because you only do getInnerText once per row
+    row_array = [];
+    col = this.sorttable_columnindex;
+    rows = this.sorttable_tbody.rows;
+    for (var j=0; j<rows.length; j++) {
+      row_array[row_array.length] = [sorttable.getInnerText(rows[j].cells[col]), rows[j]];
+    }
+    /* If you want a stable sort, uncomment the following line */
+    //sorttable.shaker_sort(row_array, this.sorttable_sortfunction);
+    /* and comment out this one */
+    row_array.sort(this.sorttable_sortfunction);
+    /* HerrVigg reverse order on first click */
+    row_array.reverse();
+
+    tb = this.sorttable_tbody;
+    for (var j=0; j<row_array.length; j++) {
+      tb.appendChild(row_array[j][1]);
+    }
+
+    delete row_array;
   },
 
   guessType: function(table, column) {
@@ -169,7 +177,8 @@ sorttable = {
     for (var i=0; i<table.tBodies[0].rows.length; i++) {
       text = sorttable.getInnerText(table.tBodies[0].rows[i].cells[column]);
       if (text != '') {
-        if (text.match(/^-?[£$¤]?[\d,.]+%?$/)) {
+        // patch Virgile Högman for spaces before %
+        if (text.match(/^-?[£$¤]?[\d,.]+[ \t]*%?$/)) {
           return sorttable.sort_numeric;
         }
         // check for a date: dd/mm/yyyy or dd/mm/yy
@@ -208,7 +217,7 @@ sorttable = {
     hasInputs = (typeof node.getElementsByTagName == 'function') &&
                  node.getElementsByTagName('input').length;
 
-    if (node.nodeType == 1 && node.getAttribute("sorttable_customkey") != null) {
+    if (node.getAttribute("sorttable_customkey") != null) {
       return node.getAttribute("sorttable_customkey");
     }
     else if (typeof node.textContent != 'undefined' && !hasInputs) {
@@ -266,7 +275,6 @@ sorttable = {
     return aa-bb;
   },
   sort_alpha: function(a,b) {
-    return a[0].localeCompare(b[0]);
     if (a[0]==b[0]) return 0;
     if (a[0]<b[0]) return -1;
     return 1;


### PR DESCRIPTION
1. Fixed major issue where the sort would work only once for each column, when updating table content dynamically. Potentially many other side effects.
Reason: multiple instances of same handler were stacked if makesortable is called several times without resetting the TH elements. This also happens if makesortable is called manually before init(). Typically the same handler could be registered twice and therefore cancelling the sort! 
Solution: no need to unregister the current handler. This can be managed very nicely giving a reference to a **unique** function (not anonymous) when calling addEventListener. See section "Multiple identical event listeners" here:
https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener

2. Fixed minor issue where **"num %"** values would not be sorted correctly if space or tabs chars were found before % char. Minor fix extending the regex.